### PR TITLE
[FSDP] enable autograd in forward prefetching

### DIFF
--- a/test/distributed/fsdp/test_fsdp_freezing_weights.py
+++ b/test/distributed/fsdp/test_fsdp_freezing_weights.py
@@ -36,8 +36,8 @@ class Model(nn.Module):
         self,
         with_fsdp,
         freeze_after_wrap_fsdp,
-        disable_autograd=False,
-        fsdp_kwargs=None,
+        disable_autograd,
+        fsdp_kwargs,
     ):
         super().__init__()
         self.trunk = nn.Sequential(
@@ -58,10 +58,6 @@ class Model(nn.Module):
         self.trunk = FSDP(self.trunk, **fsdp_kwargs)
         self.head = FSDP(self.head, **fsdp_kwargs)
 
-    @torch.no_grad()
-    def trunk_forward_no_grad(self, x):
-        return self.trunk(x)
-
     def forward(self, x):
         with self.autograd_ctx():
             x = self.trunk(x)
@@ -73,8 +69,8 @@ class NestedTrunkModel(nn.Module):
         self,
         with_fsdp,
         freeze_after_wrap_fsdp,
-        disable_autograd=False,
-        fsdp_kwargs=None,
+        disable_autograd,
+        fsdp_kwargs,
     ):
         super().__init__()
         self.trunk = nn.Sequential(
@@ -125,8 +121,8 @@ class TestFreezingWeights(FSDPTest):
         with_fsdp,
         with_nested_trunk,
         freeze_after_wrap_fsdp,
-        disable_autograd=False,
-        fsdp_kwargs=None,
+        disable_autograd,
+        fsdp_kwargs,
     ):
         if with_nested_trunk:
             model = NestedTrunkModel(
@@ -144,8 +140,8 @@ class TestFreezingWeights(FSDPTest):
         freezing_method,
         freeze_after_wrap_fsdp,
         with_fsdp,
-        disable_autograd=False,
-        forward_prefetch=False,
+        disable_autograd,
+        forward_prefetch,
     ):
         torch.manual_seed(0)
         batch = torch.randn(size=(2, 3, 224, 224)).cuda()
@@ -223,6 +219,7 @@ class TestFreezingWeights(FSDPTest):
             freeze_after_wrap_fsdp,
             with_fsdp=False,
             disable_autograd=disable_autograd,
+            forward_prefetch=False,  # does not apply to DDP
         )
 
         # FSDP

--- a/torch/distributed/fsdp/_flat_param.py
+++ b/torch/distributed/fsdp/_flat_param.py
@@ -1864,6 +1864,7 @@ class FlatParamHandle:
         return views
 
     @no_type_check
+    @torch.enable_grad()
     def _use_unsharded_views(self, as_params: bool) -> None:
         """
         Unflatten the unsharded flat parameter by setting the original parameter variables to be views into it.
@@ -1874,6 +1875,12 @@ class FlatParamHandle:
                 the original parameters only as ``Tensor`` s. ``False`` should
                 be used during forward/backward computation and when hiding the
                 original parameters from :meth:`nn.Module.named_parameters`.
+
+        Note:
+            when prefetching for next forward, current forward may be
+            annotated with `@torch.no_grad()`
+            `@torch.enable_grad()` ensures non-empty `view.grad_fn`
+            otherwise `_post_backward_hook` will not get called
         """
         flat_param = self.flat_param
         self._check_unsharded(flat_param)


### PR DESCRIPTION
**problem**
when prefetching for next forward, current forward may be annotated by `@torch.no_grad`. `param.grad_fn` keeps being None during prefetching. `_post_backward_hook` never gets triggered

repro
```pytest test/distributed/fsdp/test_fsdp_freezing_weights.py```

**solution**
this PR enabled autograd during prefetching (`_use_unsharded_views`), so
`param.grad_fn` are properly assigned for next forward

a long-term fix we can follow up is moving `_use_unsharded_views` out of
`_prefetch_handle` and put it in `_pre_forward_unshard`

